### PR TITLE
feat: enable product interactions on carousel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import TagBar from './components/TagBar.jsx';
 import ProductGrid from './components/ProductGrid.jsx';
 import Footer from './components/Footer.jsx';
 import Carousel from './components/Carousel.jsx';
+import { featuredSlides } from './data/products.js';
 
 // Modales
 import AddEditProductModal from './components/modals/AddEditProductModal.jsx';
@@ -48,7 +49,7 @@ function MainApp() {
             <div className="hidden md:block" style={{ width: '36px', minWidth: '36px' }} />
             {/* Carousel */}
             <div className="flex-1 w-full max-w-screen-2xl overflow-hidden">
-              <Carousel />
+              <Carousel slides={featuredSlides} />
             </div>
           </div>
           {/* Grid de productos */}

--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -4,9 +4,36 @@ import { Navigation, Pagination, Autoplay } from 'swiper/modules';
 import { useStore } from '../context/StoreContext';
 import CarouselAdminPanel from './CarouselAdminPanel';
 
-const Carousel = () => {
-  const { carouselSlides, user } = useStore(); // <-- importa user
+const Carousel = ({ slides }) => {
+  const { carouselSlides, user, addToCart, openProductPopup, getProductById } = useStore();
   const [showAdmin, setShowAdmin] = useState(false);
+  const [toast, setToast] = useState(null);
+
+  const slideItems = slides || carouselSlides;
+
+  const openProduct = (productId) => {
+    const product = getProductById(productId);
+    if (product) {
+      openProductPopup(product);
+    }
+  };
+
+  const handleAddToCart = (e, productId) => {
+    e.stopPropagation();
+    const product = getProductById(productId);
+    if (product) {
+      addToCart(product);
+      setToast('Producto añadido al carrito');
+      setTimeout(() => setToast(null), 2000);
+    }
+  };
+
+  const handleKeyDown = (e, productId) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      openProduct(productId);
+    }
+  };
 
   return (
     <div className="w-full min-w-0 relative">
@@ -36,17 +63,51 @@ const Carousel = () => {
         className="rounded-2xl shadow-xl"
         style={{ minWidth: 0 }}
       >
-        {carouselSlides.map((slide, i) => (
-          <SwiperSlide key={slide.id}>
-            <img
-              src={slide.imageUrl}
-              alt={slide.title || `Imagen ${i + 1}`}
-              className="w-full h-40 md:h-48 object-cover rounded-xl select-none pointer-events-none"
-              draggable={false}
-            />
-          </SwiperSlide>
-        ))}
+        {slideItems.map((slide, i) => {
+          const product = slide.productId ? getProductById(slide.productId) : null;
+          const title = slide.title || product?.name || `Imagen ${i + 1}`;
+          return (
+            <SwiperSlide key={slide.id || i}>
+              <div
+                className="relative group cursor-pointer"
+                onClick={slide.productId ? () => openProduct(slide.productId) : undefined}
+                role={slide.productId ? 'button' : undefined}
+                tabIndex={slide.productId ? 0 : -1}
+                aria-label={slide.productId ? `Ver producto: ${title}` : undefined}
+                onKeyDown={slide.productId ? (e) => handleKeyDown(e, slide.productId) : undefined}
+              >
+                <img
+                  src={slide.imageUrl}
+                  alt={title}
+                  className="w-full h-40 md:h-48 object-cover rounded-xl select-none pointer-events-none"
+                  draggable={false}
+                />
+                {slide.productId && (
+                  <div className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center gap-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 transition-opacity">
+                    <button
+                      onClick={(e) => { e.stopPropagation(); openProduct(slide.productId); }}
+                      className="px-3 py-1 bg-white text-gray-800 rounded"
+                    >
+                      Ver detalles
+                    </button>
+                    <button
+                      onClick={(e) => handleAddToCart(e, slide.productId)}
+                      className="px-4 py-1 bg-blue-600 text-white rounded-full"
+                    >
+                      Añadir al carrito
+                    </button>
+                  </div>
+                )}
+              </div>
+            </SwiperSlide>
+          );
+        })}
       </Swiper>
+      {toast && (
+        <div className="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-lg z-50">
+          {toast}
+        </div>
+      )}
       {/* Modal solo para admin */}
       {user && user.role === 'admin' && showAdmin && (
         <CarouselAdminPanel onClose={() => setShowAdmin(false)} />

--- a/src/components/modals/ProductPopupModal.jsx
+++ b/src/components/modals/ProductPopupModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useStore } from '../../context/StoreContext';
 import { COLORS } from '../../utils/constants';
 import RatingStars from "../RatingStars"; // ¡Importa aquí tu componente!
@@ -18,6 +18,7 @@ const ProductPopupModal = () => {
     closeProductPopup,
     updateThanksMessage,
     updateProduct,
+    addToCart,
     user
   } = useStore();
 
@@ -26,11 +27,15 @@ const ProductPopupModal = () => {
   const [customThanks, setCustomThanks] = useState(defaultThanks);
   const [comment, setComment] = useState('');
   const [comments, setComments] = useState([]);
+  const addCartBtnRef = useRef(null);
 
   useEffect(() => {
     if (popupProduct) {
       setCustomThanks(popupProduct.thanksMessage || defaultThanks);
       setCurrentImage(0);
+      if (addCartBtnRef.current) {
+        addCartBtnRef.current.focus();
+      }
     }
   }, [popupProduct]);
 
@@ -100,6 +105,10 @@ const ProductPopupModal = () => {
     } else if (words.length > MAX_COMMENT_WORDS) {
       alert(`El comentario es muy largo. Máximo permitido: ${MAX_COMMENT_WORDS} palabras.`);
     }
+  };
+
+  const handleAddToCart = () => {
+    addToCart(popupProduct);
   };
 
   // Trunca el texto a N palabras si es necesario
@@ -227,6 +236,16 @@ const ProductPopupModal = () => {
             {discount > 0 && (
               <span className="text-sm text-gray-400 line-through ml-3">S/ {price}</span>
             )}
+          </div>
+
+          <div className="mb-6">
+            <button
+              ref={addCartBtnRef}
+              onClick={handleAddToCart}
+              className="w-full bg-blue-600 hover:bg-blue-800 rounded-full px-4 py-2 font-semibold text-white"
+            >
+              Añadir al carrito
+            </button>
           </div>
 
           {/* Mensaje de agradecimiento */}

--- a/src/context/StoreContext.jsx
+++ b/src/context/StoreContext.jsx
@@ -77,6 +77,8 @@ export const StoreProvider = ({ children }) => {
   const [products, setProducts] = useLocalStorage('products', sampleProducts);
   const [filteredProducts, setFilteredProducts] = useState([]);
 
+  const getProductById = (id) => products.find(p => p.id === id);
+
 // Wishlist y Cart
 const [wishlist, setWishlist] = useLocalStorage('wishlist', []);
 const [cart, setCart] = useLocalStorage('cart', []);
@@ -302,6 +304,7 @@ const [showCartModal, setShowCartModal] = useState(false);
         products,
         setProducts,
         filteredProducts,
+        getProductById,
         addProduct,
         updateProduct,
         deleteProduct,

--- a/src/data/products.js
+++ b/src/data/products.js
@@ -112,3 +112,9 @@ export const sampleProducts = [
     ratings: [4, 4, 4, 4],
   }
 ];
+
+export const featuredSlides = [
+  { imageUrl: 'https://images.unsplash.com/photo-1519125323398-675f0ddb6308?auto=format&fit=crop&w=600&q=80', productId: '1', title: 'Destacado 1' },
+  { imageUrl: 'https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=1099&q=80', productId: '4', title: 'Destacado 2' },
+  { imageUrl: 'https://images.unsplash.com/photo-1596755094514-f87e34085b2c?auto=format&fit=crop&w=776&q=80', productId: '7', title: 'Destacado 3' },
+];


### PR DESCRIPTION
## Summary
- allow Carousel to open product popup and add items to cart via slide overlays
- expose getProductById helper and integrate featured slides
- focus add-to-cart button in ProductPopupModal for accessibility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c19cae1ed0832983164b669b50f159