### PR TITLE
Add show/hide toggle to password input field

### DIFF
--- a/src/components/modals/PasswordInput.jsx
+++ b/src/components/modals/PasswordInput.jsx
@@ -12,16 +12,13 @@ const PasswordInput = forwardRef(
       onChange,
       placeholder = '',
       autoComplete = 'current-password',
-      darkMode = false,
+      darkMode: _darkMode = false,
       ...inputProps
     },
     ref
   ) => {
     const [isVisible, setIsVisible] = useState(false);
-
-    const iconColorClass = darkMode
-      ? 'text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white'
-      : 'text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white';
+    void _darkMode;
 
     const toggleVisibility = () => {
       setIsVisible((prev) => !prev);
@@ -42,7 +39,7 @@ const PasswordInput = forwardRef(
             type={isVisible ? 'text' : 'password'}
             value={value}
             onChange={onChange}
-            className={`${inputClassName} pr-12`}
+            className={`${inputClassName} pr-16`}
             placeholder={placeholder}
             autoComplete={autoComplete}
             {...inputProps}
@@ -54,39 +51,9 @@ const PasswordInput = forwardRef(
             onMouseDown={(event) => {
               event.preventDefault();
             }}
-            className={`absolute inset-y-0 right-2 z-10 flex items-center px-1 focus:outline-none ${iconColorClass}`}
+            className="absolute inset-y-0 right-4 z-10 flex items-center text-sm font-medium text-blue-600 hover:text-blue-800 focus:outline-none"
           >
-            {isVisible ? (
-              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                />
-              </svg>
-            ) : (
-              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a9.993 9.993 0 012.293-3.95m2.724-2.632A9.956 9.956 0 0112 5c4.478 0 8.268 2.943 9.542 7-.512 1.634-1.436 3.064-2.662 4.116M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3 3l18 18"
-                />
-              </svg>
-            )}
+            {isVisible ? 'Hide' : 'Show'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the login modal password input to use a Show/Hide toggle button with blue text
- add padding to the input to accommodate the inline button and keep autocomplete support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d38095848329863c2f754afd208c